### PR TITLE
Fixed cwdaemon not sending text

### DIFF
--- a/core/cwdaemon/cwdaemon.go
+++ b/core/cwdaemon/cwdaemon.go
@@ -1,8 +1,6 @@
 package cwdaemon
 
 import (
-	"log"
-
 	"github.com/ftl/hamradio/cwclient"
 
 	"github.com/ftl/hellocontest/core/network"
@@ -94,10 +92,14 @@ func (c *Client) Speed(wpm int) {
 }
 
 func (c *Client) Send(text string) {
-	err := c.connect()
-	if err != nil {
-		log.Printf("cannot send %q: %v", text, err)
+	if !c.client.IsConnected() {
+		if c.connected {
+			c.connected = false
+			c.emitConnectionChanged(false)
+		}
+		return
 	}
+	c.client.Send(text)
 }
 
 func (c *Client) Abort() {


### PR DESCRIPTION
cwdaemon client was not sending text due to a (forgotten?) missing implementation. Fixed that and performed development testing.