### PR TITLE
Improve Bandmap Concurrency

### DIFF
--- a/core/bandmap/bandmap.go
+++ b/core/bandmap/bandmap.go
@@ -260,12 +260,6 @@ func (m *Bandmap) Notify(listener any) {
 	}
 }
 
-func (m *Bandmap) Clear() {
-	m.do <- func() {
-		m.entries.Clear()
-	}
-}
-
 func (m *Bandmap) Add(spot core.Spot) {
 	m.do <- func() {
 		mode := spot.Mode
@@ -281,22 +275,6 @@ func (m *Bandmap) Add(spot core.Spot) {
 
 		m.entries.Add(spot, m.clock.Now(), m.weights)
 	}
-}
-
-func (m *Bandmap) AllBy(order core.BandmapOrder) []core.BandmapEntry {
-	result := make(chan []core.BandmapEntry)
-	m.do <- func() {
-		result <- m.entries.AllBy(order)
-	}
-	return <-result
-}
-
-func (m *Bandmap) Query(order core.BandmapOrder, filters ...core.BandmapFilter) []core.BandmapEntry {
-	result := make(chan []core.BandmapEntry)
-	m.do <- func() {
-		result <- m.entries.Query(order, filters...)
-	}
-	return <-result
 }
 
 func (m *Bandmap) SelectEntry(id core.BandmapEntryID) {

--- a/core/bandmap/bandmap.go
+++ b/core/bandmap/bandmap.go
@@ -49,12 +49,12 @@ type Bandmap struct {
 	clock       core.Clock
 	view        View
 	dupeChecker DupeChecker
+	vfo         core.VFO
 
-	vfo             core.VFO
+	activeMode      core.Mode
 	activeFrequency core.Frequency
 	activeBand      core.Band
 	visibleBand     core.Band
-	activeMode      core.Mode
 
 	updatePeriod time.Duration
 	maximumAge   time.Duration
@@ -224,6 +224,7 @@ func (m *Bandmap) ScoreUpdated(_ core.Score) {
 func (m *Bandmap) VFOFrequencyChanged(frequency core.Frequency) {
 	m.do <- func() {
 		m.activeFrequency = frequency
+		// the frame is not updated with every frequency change, this creates too much load
 	}
 }
 

--- a/core/bandmap/entries.go
+++ b/core/bandmap/entries.go
@@ -160,13 +160,22 @@ func (e *Entry) updateFrequency() bool {
 	return oldFrequency != e.Frequency
 }
 
-func (e *Entry) matchesFilters(filters ...core.BandmapFilter) bool {
+func (e *Entry) MatchesAllFilters(filters ...core.BandmapFilter) bool {
 	for _, filter := range filters {
 		if !filter(e.BandmapEntry) {
 			return false
 		}
 	}
 	return true
+}
+
+func (e *Entry) MatchesAnyFilter(filters ...core.BandmapFilter) bool {
+	for _, filter := range filters {
+		if filter(e.BandmapEntry) {
+			return true
+		}
+	}
+	return false
 }
 
 type EntryAddedListener interface {
@@ -489,7 +498,7 @@ func (l *Entries) AllBy(order core.BandmapOrder) []core.BandmapEntry {
 func (l *Entries) Query(order core.BandmapOrder, filters ...core.BandmapFilter) []core.BandmapEntry {
 	result := make([]core.BandmapEntry, 0, len(l.entries))
 	for _, e := range l.entries {
-		if e.matchesFilters(filters...) {
+		if e.MatchesAllFilters(filters...) {
 			result = append(result, e.BandmapEntry)
 		}
 	}

--- a/core/bandmap/entries.go
+++ b/core/bandmap/entries.go
@@ -236,7 +236,7 @@ func (l *Entries) Add(spot core.Spot, now time.Time, weights core.BandmapWeights
 		if added {
 			e.Info = l.callinfo.GetInfo(spot.Call, spot.Band, spot.Mode, []string{})
 			e.Info.WeightedValue = l.calculateWeightedValue(e, now, weights)
-			l.notifier.emitEntryUpdated(*e)
+			l.notifier.emitEntryUpdated(e.BandmapEntry)
 			return
 		}
 		if entryQuality < quality {
@@ -251,7 +251,7 @@ func (l *Entries) Add(spot core.Spot, now time.Time, weights core.BandmapWeights
 		newEntry.Info.WeightedValue = l.calculateWeightedValue(&newEntry, now, weights)
 	}
 	l.insert(&newEntry)
-	l.notifier.emitEntryAdded(newEntry)
+	l.notifier.emitEntryAdded(newEntry.BandmapEntry)
 }
 
 func (l *Entries) insert(entry *Entry) {
@@ -300,7 +300,7 @@ func (l *Entries) CleanOut(maximumAge time.Duration, now time.Time, weights core
 		l.entries[i] = e
 
 		if updated {
-			l.notifier.emitEntryUpdated(*e)
+			l.notifier.emitEntryUpdated(e.BandmapEntry)
 		}
 		if l.countEntryValue(e.BandmapEntry) {
 			l.addToSummary(e)
@@ -316,7 +316,7 @@ func (l *Entries) cleanOutOldEntries(maximumAge time.Duration, now time.Time) {
 			if l.selectedEntry != nil && e.ID == l.selectedEntry.ID {
 				l.selectedEntry = nil
 			}
-			l.notifier.emitEntryRemoved(*e)
+			l.notifier.emitEntryRemoved(e.BandmapEntry)
 		}
 		return stillValid
 	})
@@ -396,24 +396,6 @@ func (l *Entries) DoOnEntry(id core.BandmapEntryID, f func(core.BandmapEntry)) {
 		}
 	}
 	f(core.BandmapEntry{})
-}
-
-func (l *Entries) Select(id core.BandmapEntryID) {
-	l.selectedEntry = nil
-	for _, entry := range l.entries {
-		if entry.ID == id {
-			l.selectedEntry = entry
-			l.notifier.emitEntrySelected(*entry)
-			return
-		}
-	}
-}
-
-func (l *Entries) SelectedEntry() (core.BandmapEntry, bool) {
-	if l.selectedEntry == nil {
-		return core.BandmapEntry{}, false
-	}
-	return l.selectedEntry.BandmapEntry, true
 }
 
 func (l *Entries) All() []core.BandmapEntry {

--- a/core/bandmap/entries.go
+++ b/core/bandmap/entries.go
@@ -4,10 +4,10 @@ import (
 	"math"
 	"time"
 
+	"github.com/ftl/hamradio/callsign"
 	"github.com/texttheater/golang-levenshtein/levenshtein"
 	"golang.org/x/exp/slices"
 
-	"github.com/ftl/hamradio/callsign"
 	"github.com/ftl/hellocontest/core"
 )
 

--- a/core/bandmap/entries.go
+++ b/core/bandmap/entries.go
@@ -186,7 +186,6 @@ type Entries struct {
 	callinfo        Callinfo
 	countEntryValue func(core.BandmapEntry) bool
 	lastID          core.BandmapEntryID
-	selectedEntry   *Entry
 
 	notifier *Notifier
 }
@@ -313,9 +312,6 @@ func (l *Entries) cleanOutOldEntries(maximumAge time.Duration, now time.Time) {
 	l.entries = filterSlice(l.entries, func(e *Entry) bool {
 		stillValid := e.RemoveSpotsBefore(deadline)
 		if !stillValid {
-			if l.selectedEntry != nil && e.ID == l.selectedEntry.ID {
-				l.selectedEntry = nil
-			}
 			l.notifier.emitEntryRemoved(e.BandmapEntry)
 		}
 		return stillValid

--- a/core/bandmap/entries_test.go
+++ b/core/bandmap/entries_test.go
@@ -159,7 +159,7 @@ func TestEntry_RemoveSpotsBefore(t *testing.T) {
 
 func TestEntries_AddNewEntry(t *testing.T) {
 	now := time.Now()
-	entries := NewEntries(countAllEntries)
+	entries := NewEntries(&Notifier{}, countAllEntries)
 	assert.Equal(t, 0, entries.Len())
 
 	entries.Add(core.Spot{Call: callsign.MustParse("dl1abc"), Frequency: 3760000, Time: now}, now, defaultWeights)
@@ -344,7 +344,7 @@ func TestEntries_insert(t *testing.T) {
 
 func TestEntries_QueryByFilters(t *testing.T) {
 	now := time.Now()
-	entries := NewEntries(countAllEntries)
+	entries := NewEntries(&Notifier{}, countAllEntries)
 	entries.Add(core.Spot{Call: callsign.MustParse("DL1ABC"), Frequency: 7020000, Band: core.Band40m, Source: core.ManualSpot}, now.Add(-1*time.Minute), defaultWeights)
 	entries.Add(core.Spot{Call: callsign.MustParse("DL2ABC"), Frequency: 14015000, Band: core.Band20m, Source: core.ManualSpot}, now.Add(-2*time.Minute), defaultWeights)
 	entries.Add(core.Spot{Call: callsign.MustParse("DL3ABC"), Frequency: 14030000, Band: core.Band20m, Source: core.ClusterSpot}, now.Add(-2*time.Minute), defaultWeights)
@@ -388,7 +388,7 @@ func TestEntries_QueryByFilters(t *testing.T) {
 
 func TestEntries_CleanOutOldEntries(t *testing.T) {
 	now := time.Now()
-	entries := NewEntries(countAllEntries)
+	entries := NewEntries(&Notifier{}, countAllEntries)
 
 	entries.Add(core.Spot{Call: callsign.MustParse("dl1abc"), Frequency: 3535000, Time: now.Add(-1 * time.Hour)}, now, defaultWeights)
 	entries.Add(core.Spot{Call: callsign.MustParse("dl1abc"), Frequency: 3535000, Time: now.Add(-30 * time.Minute)}, now, defaultWeights)
@@ -411,9 +411,10 @@ func TestEntries_CleanOutOldEntries(t *testing.T) {
 
 func TestEntries_Notify(t *testing.T) {
 	now := time.Now()
-	entries := NewEntries(countAllEntries)
+	notifier := &Notifier{}
+	entries := NewEntries(notifier, countAllEntries)
 	listener := new(testEntryListener)
-	entries.Notify(listener)
+	notifier.Notify(listener)
 
 	entries.Add(core.Spot{Call: callsign.MustParse("dl1abc"), Frequency: 3535000, Time: now.Add(-1 * time.Hour)}, now, defaultWeights)
 	assert.Equal(t, "DL1ABC", listener.added[0].Call.String())

--- a/core/bandmap/notify.go
+++ b/core/bandmap/notify.go
@@ -32,34 +32,34 @@ func (n *Notifier) Notify(listener any) {
 	n.listeners = append(n.listeners, listener)
 }
 
-func (n *Notifier) emitEntryAdded(e Entry) {
+func (n *Notifier) emitEntryAdded(e core.BandmapEntry) {
 	for _, listener := range n.listeners {
 		if entryAddedListener, ok := listener.(EntryAddedListener); ok {
-			entryAddedListener.EntryAdded(e.BandmapEntry)
+			entryAddedListener.EntryAdded(e)
 		}
 	}
 }
 
-func (n *Notifier) emitEntryUpdated(e Entry) {
+func (n *Notifier) emitEntryUpdated(e core.BandmapEntry) {
 	for _, listener := range n.listeners {
 		if entryUpdatedListener, ok := listener.(EntryUpdatedListener); ok {
-			entryUpdatedListener.EntryUpdated(e.BandmapEntry)
+			entryUpdatedListener.EntryUpdated(e)
 		}
 	}
 }
 
-func (n *Notifier) emitEntryRemoved(e Entry) {
+func (n *Notifier) emitEntryRemoved(e core.BandmapEntry) {
 	for _, listener := range n.listeners {
 		if entryRemovedListener, ok := listener.(EntryRemovedListener); ok {
-			entryRemovedListener.EntryRemoved(e.BandmapEntry)
+			entryRemovedListener.EntryRemoved(e)
 		}
 	}
 }
 
-func (n *Notifier) emitEntrySelected(e Entry) {
+func (n *Notifier) emitEntrySelected(e core.BandmapEntry) {
 	for _, listener := range n.listeners {
 		if entrySelectedListener, ok := listener.(EntrySelectedListener); ok {
-			entrySelectedListener.EntrySelected(e.BandmapEntry)
+			entrySelectedListener.EntrySelected(e)
 		}
 	}
 }

--- a/core/bandmap/notify.go
+++ b/core/bandmap/notify.go
@@ -1,0 +1,73 @@
+package bandmap
+
+import (
+	"github.com/ftl/hellocontest/core"
+)
+
+type EntryAddedListener interface {
+	EntryAdded(core.BandmapEntry)
+}
+
+type EntryUpdatedListener interface {
+	EntryUpdated(core.BandmapEntry)
+}
+
+type EntryRemovedListener interface {
+	EntryRemoved(core.BandmapEntry)
+}
+
+type EntrySelectedListener interface {
+	EntrySelected(core.BandmapEntry)
+}
+
+type EntryOnFrequencyListener interface {
+	EntryOnFrequency(core.BandmapEntry, bool)
+}
+
+type Notifier struct {
+	listeners []any
+}
+
+func (n *Notifier) Notify(listener any) {
+	n.listeners = append(n.listeners, listener)
+}
+
+func (n *Notifier) emitEntryAdded(e Entry) {
+	for _, listener := range n.listeners {
+		if entryAddedListener, ok := listener.(EntryAddedListener); ok {
+			entryAddedListener.EntryAdded(e.BandmapEntry)
+		}
+	}
+}
+
+func (n *Notifier) emitEntryUpdated(e Entry) {
+	for _, listener := range n.listeners {
+		if entryUpdatedListener, ok := listener.(EntryUpdatedListener); ok {
+			entryUpdatedListener.EntryUpdated(e.BandmapEntry)
+		}
+	}
+}
+
+func (n *Notifier) emitEntryRemoved(e Entry) {
+	for _, listener := range n.listeners {
+		if entryRemovedListener, ok := listener.(EntryRemovedListener); ok {
+			entryRemovedListener.EntryRemoved(e.BandmapEntry)
+		}
+	}
+}
+
+func (n *Notifier) emitEntrySelected(e Entry) {
+	for _, listener := range n.listeners {
+		if entrySelectedListener, ok := listener.(EntrySelectedListener); ok {
+			entrySelectedListener.EntrySelected(e.BandmapEntry)
+		}
+	}
+}
+
+func (n *Notifier) emitEntryOnFrequency(e core.BandmapEntry, available bool) {
+	for _, listener := range n.listeners {
+		if nearestEntryListener, ok := listener.(EntryOnFrequencyListener); ok {
+			nearestEntryListener.EntryOnFrequency(e, available)
+		}
+	}
+}

--- a/core/bandmap/selection.go
+++ b/core/bandmap/selection.go
@@ -1,0 +1,107 @@
+package bandmap
+
+import (
+	"github.com/ftl/hamradio/callsign"
+
+	"github.com/ftl/hellocontest/core"
+)
+
+type Selection struct {
+	selectedEntry core.BandmapEntry
+	selected      bool
+
+	entries       *Entries
+	visibleFilter core.BandmapFilter
+}
+
+func NewSelection(entries *Entries, visibleFilter core.BandmapFilter) *Selection {
+	return &Selection{
+		entries:       entries,
+		visibleFilter: visibleFilter,
+	}
+}
+
+func (s *Selection) selectEntry(entry core.BandmapEntry) {
+	s.selectedEntry = entry
+	s.selected = true
+
+	// TODO s.emitEntrySelected(entry)
+}
+
+func (s *Selection) clear() {
+	s.selectedEntry = core.BandmapEntry{}
+	s.selected = false
+
+	// TODO s.emitEntrySelected(core.BandmapEntry{})
+}
+
+func (s *Selection) findAndSelect(order core.BandmapOrder, filters ...core.BandmapFilter) {
+	entries := s.entries.Query(order, filters...)
+	if len(entries) > 0 {
+		s.selectEntry(entries[0])
+	}
+}
+
+func (s *Selection) SelectEntry(id core.BandmapEntryID) {
+	found := false
+	s.entries.ForEach(func(entry core.BandmapEntry) bool {
+		if entry.ID == id && s.visibleFilter(entry) {
+			s.selectEntry(entry)
+			found = true
+			return true
+		}
+		return false
+	})
+	if !found {
+		s.clear()
+	}
+}
+
+func (s *Selection) SelectByCallsign(call callsign.Callsign) {
+	callStr := call.String()
+	s.entries.ForEach(func(entry core.BandmapEntry) bool {
+		if entry.Call.String() == callStr && s.visibleFilter(entry) {
+			s.selectEntry(entry)
+			return true
+		}
+		return false
+	})
+}
+
+func (s *Selection) SelectHighestValue() {
+	s.findAndSelect(
+		core.Descending(core.BandmapByValue),
+		s.visibleFilter,
+		core.Not(core.IsWorkedSpot),
+	)
+}
+
+func (s *Selection) SelectNearest(frequency core.Frequency) {
+	s.findAndSelect(
+		core.BandmapByDistance(frequency),
+		s.visibleFilter,
+		core.Not(core.OnFrequency(frequency)),
+	)
+}
+
+func (s *Selection) SelectNextUp(frequency core.Frequency) {
+	s.findAndSelect(
+		core.BandmapByDistance(frequency),
+		s.visibleFilter,
+		func(entry core.BandmapEntry) bool {
+			return (entry.Frequency > frequency) ||
+				(s.selected && entry.Frequency == frequency && entry.ID > s.selectedEntry.ID)
+		},
+	)
+}
+
+func (s *Selection) SelectNextDown(frequency core.Frequency) {
+	s.findAndSelect(
+		core.BandmapByDistance(frequency),
+		s.visibleFilter,
+		func(entry core.BandmapEntry) bool {
+			return (entry.Frequency > frequency) ||
+				(s.selected && entry.Frequency == frequency && entry.ID > s.selectedEntry.ID)
+		},
+	)
+}

--- a/core/core.go
+++ b/core/core.go
@@ -1020,6 +1020,17 @@ func BandmapByDistance(referenceFrequency Frequency) BandmapOrder {
 	}
 }
 
+func BandmapByDistanceAndDescendingID(referenceFrequency Frequency) BandmapOrder {
+	return func(a, b BandmapEntry) bool {
+		deltaA := math.Abs(float64(a.Frequency - referenceFrequency))
+		deltaB := math.Abs(float64(b.Frequency - referenceFrequency))
+		if deltaA == deltaB {
+			return a.ID > b.ID
+		}
+		return deltaA < deltaB
+	}
+}
+
 func BandmapByValue(a, b BandmapEntry) bool {
 	if a.Info.WeightedValue == b.Info.WeightedValue {
 		return a.ID < b.ID

--- a/core/core.go
+++ b/core/core.go
@@ -1029,6 +1029,44 @@ func BandmapByValue(a, b BandmapEntry) bool {
 
 type BandmapFilter func(entry BandmapEntry) bool
 
+func And(filters ...BandmapFilter) BandmapFilter {
+	return func(entry BandmapEntry) bool {
+		for _, filter := range filters {
+			if !filter(entry) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+func Or(filters ...BandmapFilter) BandmapFilter {
+	return func(entry BandmapEntry) bool {
+		for _, filter := range filters {
+			if filter(entry) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func Not(filter BandmapFilter) BandmapFilter {
+	return func(entry BandmapEntry) bool {
+		return !filter(entry)
+	}
+}
+
+func IsWorkedSpot(entry BandmapEntry) bool {
+	return entry.Source == WorkedSpot
+}
+
+func OnFrequency(frequency Frequency) BandmapFilter {
+	return func(entry BandmapEntry) bool {
+		return entry.OnFrequency(frequency)
+	}
+}
+
 func OnBand(band Band) BandmapFilter {
 	return func(entry BandmapEntry) bool {
 		return entry.Band == band

--- a/core/entry/entry.go
+++ b/core/entry/entry.go
@@ -81,7 +81,6 @@ type Callinfo interface {
 type Bandmap interface {
 	Add(core.Spot)
 
-	AllBy(core.BandmapOrder) []core.BandmapEntry
 	SelectByCallsign(callsign.Callsign) bool
 }
 

--- a/core/entry/entry.go
+++ b/core/entry/entry.go
@@ -80,8 +80,7 @@ type Callinfo interface {
 
 type Bandmap interface {
 	Add(core.Spot)
-
-	SelectByCallsign(callsign.Callsign) bool
+	SelectByCallsign(callsign.Callsign)
 }
 
 // NewController returns a new entry controller.
@@ -1007,6 +1006,5 @@ func (n *nullCallinfo) PredictedExchange() []string                     { return
 
 type nullBandmap struct{}
 
-func (n *nullBandmap) Add(core.Spot)                               {}
-func (n *nullBandmap) AllBy(core.BandmapOrder) []core.BandmapEntry { return nil }
-func (n *nullBandmap) SelectByCallsign(callsign.Callsign) bool     { return false }
+func (n *nullBandmap) Add(core.Spot)                      {}
+func (n *nullBandmap) SelectByCallsign(callsign.Callsign) {}

--- a/docs/bandmap_interaction.md
+++ b/docs/bandmap_interaction.md
@@ -1,0 +1,31 @@
+```mermaid
+mindmap
+  root((Bandmap))
+    Setup
+        Close
+        SetView
+        SetVFO
+        SetCallinfo
+        Notify
+    UI: Direct Interaction
+        Show
+        Hide
+        SelectEntry
+        SelectByCallsign
+        GotoHighestValueEntry
+        GotoNearestEntry
+        GotoNextEntryUp
+        GotoNextEntryDown
+        SetVisibleBand
+        SetActiveBand
+    UI: Event Handling
+        ContestChanged
+        ScoreUpdated
+    VFO
+        VFOFrequencyChanged
+        VFOBandChanged
+        VFOModeChanged
+    Add
+        UI: Entry
+        Cluster
+```


### PR DESCRIPTION
This change untangles the responsibilities within the bandmap package into separate types on different levels of abstraction. The implementation its public interface and the use of other entities (Callinfo, QSOList) are much clearer and easier to comprehend. This will make future extensions easier.

- [x] listener and event handling
- [x] selection handling
- [x] view state
- [x] retrieval of data from other entities (Callinfo, QSOList)