### PR TITLE
polish sponsor list

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -373,8 +373,14 @@ func (c *Controller) OpenWiki() {
 
 func (c *Controller) About() {
 	var sponsorText string
-	if strings.TrimSpace(c.sponsors) != "" {
-		sponsorText = fmt.Sprintf("sponsored by:\n%s\n\n", c.sponsors)
+
+	sponsors := strings.Split(c.sponsors, "\n")
+	if len(sponsors) > 0 {
+		for sponsors[len(sponsors)-1] == "" {
+			sponsors = sponsors[:len(sponsors)-1]
+		}
+		sponsorsCSV := strings.Join(sponsors, ", ")
+		sponsorText = fmt.Sprintf("sponsored by:\n%s\n\n", sponsorsCSV)
 	}
 
 	c.view.ShowInfoDialog("Hello Contest\n\nVersion %s\n\n%sThis software is published under the MIT License.\n(c) Florian Thienel/DL3NEY", c.version, sponsorText)

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func main() {
 			fmt.Println(version)
 			os.Exit(0)
 		case os.Args[1] == "sponsors":
-			fmt.Printf("This release of Hello Contest is sponsored by %s\n", sponsors)
+			fmt.Printf("This release of Hello Contest is sponsored by:\n%s\nThank you all for your great support!\n73, Florian\n", sponsors)
 			os.Exit(0)
 		case os.Args[1] == "screenshots":
 			startupScript = script.ScreenshotsScript

--- a/sponsors.txt
+++ b/sponsors.txt
@@ -1,2 +1,2 @@
-Theo DL3NY
-Stephan DF2NK
+Theo/DL3NY
+Stephan/DF2NK

--- a/sponsors.txt
+++ b/sponsors.txt
@@ -1,1 +1,2 @@
-     
+Theo DL3NY
+Stephan DF2NK


### PR DESCRIPTION
- add the all-time sponsors DL3NY and DF2NK
- show the list line-by-line on the command line (`hellocontest sponsors`)
- keep the comma separated visualisation in the about dialog